### PR TITLE
TEST: implement conftest and check api availability

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,8 @@ Dockerfile
 **/__pycache__
 **/*.pyc
 **/*.md
+**/*.sh
+**/*.ini
 **/*.yml
 **/*.yaml
 **/*.example

--- a/.gitignore
+++ b/.gitignore
@@ -163,6 +163,9 @@ cython_debug/
 config.yaml
 docker-compose.yaml
 docker-compose.dev.yaml
+# Note: at some point we may provide active test nodes in conftest.ini
+#conftest.ini
+conftest.dev.ini
 
 # Deprecated!
 docker.txt

--- a/conftest.dev.ini.example
+++ b/conftest.dev.ini.example
@@ -1,0 +1,4 @@
+# pytest configuration example for "conftest" (file: conftest.dev.ini)
+# note that the "[conftest]" section is static and required!
+[conftest]
+api_url = http://localhost:8000

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,23 @@
+import requests
+import pytest
+
+# Configure pytest
+def pytest_configure(config):
+    pytest.api_url = 'http://localhost:8000'
+    pytest.api_unavailable = api_unavailable()
+    # Uncomment the below to stop ALL tests if the SyncLink Server is down
+    # if pytest.api_unavailable:
+    #     pytest.exit(f'FATAL - API unavailable: {pytest.api_url}')
+
+# Use this to "skipif" individual tests that require an available API
+def api_unavailable(api_url = None):
+    if "status" not in api_unavailable.__dict__ : api_unavailable.status = None
+    if api_unavailable.status != None:
+        return api_unavailable.status
+    try:
+        api_url = api_url if api_url != None else pytest.api_url
+        request = requests.get(api_url, timeout = 5)
+        api_unavailable.status = False
+    except requests.exceptions.ConnectionError:
+        api_unavailable.status = True
+    return api_unavailable.status

--- a/conftest.py
+++ b/conftest.py
@@ -1,9 +1,10 @@
 import requests
 import pytest
+import configparser
 
 # Configure pytest
 def pytest_configure(config):
-    pytest.api_url = 'http://localhost:8000'
+    pytest.api_url = get_conftest_setting('api_url','http://localhost:8000')
     pytest.api_unavailable = api_unavailable()
     # Uncomment the below to stop ALL tests if the SyncLink Server is down
     # if pytest.api_unavailable:
@@ -21,3 +22,23 @@ def api_unavailable(api_url = None):
     except requests.exceptions.ConnectionError:
         api_unavailable.status = True
     return api_unavailable.status
+
+# Get conftest setting if either conftest.dev.ini or conftest.ini exists
+# Note that the keys in "conftest.dev.ini" will overwrite "conftest.ini"
+# The mentioned order above is mandatory and the file format is fixed:
+# [conftest]
+# key = value 
+def get_conftest_setting(key,default=None):
+    bn = "conftest"
+    ext = "ini"
+    dev = "dev"
+    filename = f"{bn}.{ext}"
+    filename_dev = f"{bn}.{dev}.{ext}"
+    config = configparser.ConfigParser()
+    try:
+        config.read([filename,filename_dev])
+    except:
+        pass
+    if not "conftest" in config:
+        return default
+    return config["conftest"][key] if key in config["conftest"] else default

--- a/services/tests/eth2api_test.py
+++ b/services/tests/eth2api_test.py
@@ -4,10 +4,11 @@ import pytest
 
 from services.eth2api import ETH2API
 
-api = ETH2API('http://localhost:8000')
+api = ETH2API(pytest.api_url)
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(pytest.api_unavailable, reason="API unavailable")
 async def test_beacon_genesis():
     genesis = await api.beacon.genesis()
 
@@ -15,6 +16,7 @@ async def test_beacon_genesis():
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(pytest.api_unavailable, reason="API unavailable")
 async def test_beacon_block_root():
     block_root = await api.beacon.block_root(block_id=0)
 
@@ -22,6 +24,7 @@ async def test_beacon_block_root():
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(pytest.api_unavailable, reason="API unavailable")
 async def test_beacon_state_finality_checkpoints():
     finality = await api.beacon.state_finality_checkpoints(state_id='head')
 
@@ -29,6 +32,7 @@ async def test_beacon_state_finality_checkpoints():
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(pytest.api_unavailable, reason="API unavailable")
 async def test_beacon_block():
     block_id = '0'
 
@@ -38,6 +42,7 @@ async def test_beacon_block():
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(pytest.api_unavailable, reason="API unavailable")
 async def test_config_spec():
     spec = await api.config.spec()
 
@@ -45,6 +50,7 @@ async def test_config_spec():
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(pytest.api_unavailable, reason="API unavailable")
 async def test_config_deposit_contract():
     deposit_contract = await api.config.deposit_contract()
 
@@ -52,6 +58,7 @@ async def test_config_deposit_contract():
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(pytest.api_unavailable, reason="API unavailable")
 async def test_config_fork_schedule():
     fork_schedule = await api.config.fork_schedule()
 
@@ -59,6 +66,7 @@ async def test_config_fork_schedule():
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(pytest.api_unavailable, reason="API unavailable")
 async def test_node_health():
     health = await api.node.health()
 
@@ -66,6 +74,7 @@ async def test_node_health():
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(pytest.api_unavailable, reason="API unavailable")
 async def test_node_syncing():
     syncing = await api.node.syncing()
 
@@ -73,6 +82,7 @@ async def test_node_syncing():
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(pytest.api_unavailable, reason="API unavailable")
 async def test_node_version():
     version = await api.node.version()
 
@@ -80,6 +90,7 @@ async def test_node_version():
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(pytest.api_unavailable, reason="API unavailable")
 async def test_node_peers():
     peers = await api.node.peers()
 
@@ -87,6 +98,7 @@ async def test_node_peers():
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(pytest.api_unavailable, reason="API unavailable")
 async def test_node_peer_count():
     peer_count = await api.node.peer_count()
 

--- a/services/tests/synclink_api_test.py
+++ b/services/tests/synclink_api_test.py
@@ -4,10 +4,11 @@ import pytest
 
 from services.synclink_api import SyncLink
 
-syncLink = SyncLink('http://localhost:8000')
+syncLink = SyncLink(pytest.api_url)
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(pytest.api_unavailable, reason="API unavailable")
 async def test_synclink_server_is_ready():
     is_ready = await syncLink.server.is_ready()
 
@@ -15,6 +16,7 @@ async def test_synclink_server_is_ready():
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(pytest.api_unavailable, reason="API unavailable")
 async def test_synclink_server_get_config():
     config = await syncLink.server.config()
 


### PR DESCRIPTION
- make pytest available in virtualenv from root directory
- make test vars available globally
- skip specific tests when server API is down (required for ci)